### PR TITLE
Add resetOnExpire flag

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -68,6 +68,19 @@ describe('useCountdownTimer', () => {
       expect(result.current.countdown).toBe(timer);
     });
 
+    it('countdown not resets to timer', () => {
+      const timer = 5 * 1000;
+      const { result } = renderHook(() =>
+        useCountdownTimer({ timer, autostart: true, resetOnExpire: false })
+      );
+
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      expect(result.current.countdown).toBe(0);
+    });
+
     it('countdown is not running w/ autostart: true', () => {
       const timer = 5 * 1000;
       const { result } = renderHook(() =>

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -55,7 +55,7 @@ describe('useCountdownTimer', () => {
   });
 
   describe('after expiration', () => {
-    it('countdown resets to timer', () => {
+    it('countdown resets to timer w/ resetOnExpire: true', () => {
       const timer = 5 * 1000;
       const { result } = renderHook(() =>
         useCountdownTimer({ timer, autostart: true })
@@ -68,7 +68,7 @@ describe('useCountdownTimer', () => {
       expect(result.current.countdown).toBe(timer);
     });
 
-    it('countdown not resets to timer', () => {
+    it('countdown does not reset to timer w/ resetOnExpire: false', () => {
       const timer = 5 * 1000;
       const { result } = renderHook(() =>
         useCountdownTimer({ timer, autostart: true, resetOnExpire: false })
@@ -79,6 +79,47 @@ describe('useCountdownTimer', () => {
       });
 
       expect(result.current.countdown).toBe(0);
+    });
+
+    it('must reset before start w/ resetOnExpire: false', () => {
+      const timer = 5 * 1000;
+      const onExpire = jest.fn();
+      const { result } = renderHook(() =>
+        useCountdownTimer({
+          timer,
+          autostart: true,
+          onExpire,
+          resetOnExpire: false,
+        })
+      );
+
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      expect(result.current.countdown).toBe(0);
+      expect(onExpire).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        result.current.start();
+      });
+
+      // start without reset = noop and no onExpire call
+      expect(result.current.countdown).toBe(0);
+      expect(onExpire).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        result.current.reset();
+      });
+
+      act(() => {
+        result.current.start();
+        jest.runAllTimers();
+      });
+
+      // reset before start = running timer and onExpire called
+      expect(result.current.countdown).toBe(0);
+      expect(onExpire).toHaveBeenCalledTimes(2);
     });
 
     it('countdown is not running w/ autostart: true', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ export function useCountdownTimer({
     if (onExpire && typeof onExpire === 'function') {
       onExpire();
     }
-  }, [timer, onExpire]);
+  }, [timer, onExpire, resetOnExpire]);
 
   const countdownRef = useRef<number>(timer);
   useEffect(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export interface ICountdownTimerParams {
   interval?: number;
   autostart?: boolean;
   expireImmediate?: boolean;
+  resetOnExpire?: boolean;
   onExpire?: () => void;
   onReset?: () => void;
 }
@@ -22,6 +23,7 @@ export function useCountdownTimer({
   interval = 1000,
   autostart = false,
   expireImmediate = false,
+  resetOnExpire = true,
   onExpire,
   onReset,
 }: ICountdownTimerParams): CountdownTimerResults {
@@ -52,7 +54,7 @@ export function useCountdownTimer({
   }, [timer, onReset]);
 
   const expire = useCallback(() => {
-    initStopped(timer);
+    initStopped(resetOnExpire ? timer : 0);
     if (onExpire && typeof onExpire === 'function') {
       onExpire();
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,10 @@ export function useCountdownTimer({
   const [isRunning, setIsRunning] = useState(false);
 
   function start() {
-    setCanStart(true);
+    // must explicitly call reset() before starting an expired timer
+    if (countdown !== 0) {
+      setCanStart(true);
+    }
   }
 
   function pause() {


### PR DESCRIPTION
Hey @LobsterBandit ,
concerning this issue https://github.com/LobsterBandit/use-countdown-timer/issues/5 I created a simple addition to your countdown hook.

I've set the `resetOnExpire` flag to true by default to match the current behavior and not introduce a breaking change.
Test is also included.

Hope this fits for you. If you have any concerns or comments, let me know. :)
Best, Jan